### PR TITLE
Made IconCustomEmojiId nullable

### DIFF
--- a/src/Telegram.BotAPI/Available Types/ForumTopic.cs
+++ b/src/Telegram.BotAPI/Available Types/ForumTopic.cs
@@ -35,5 +35,5 @@ public sealed class ForumTopic
 	/// </summary>
 	[JsonPropertyName(PropertyNames.IconCustomEmojiId)]
 	[JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-	public string IconCustomEmojiId { get; set; }
+	public string? IconCustomEmojiId { get; set; }
 }

--- a/src/Telegram.BotAPI/Available Types/ForumTopicCreated.cs
+++ b/src/Telegram.BotAPI/Available Types/ForumTopicCreated.cs
@@ -29,5 +29,5 @@ public sealed class ForumTopicCreated
 	/// </summary>
 	[JsonPropertyName(PropertyNames.IconCustomEmojiId)]
 	[JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-	public string IconCustomEmojiId { get; set; }
+	public string? IconCustomEmojiId { get; set; }
 }


### PR DESCRIPTION
`IconCustomEmojiId` was made nullable in `ForumTopic` and `ForumTopicCreated`, so now we do not get a 400 error when deserializing a `Message` from topic without custom emoji as discribed in #31